### PR TITLE
Fixed typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ public void ConfigureServices(IServiceCollection services)
     services.AddWebpack();
 }
 
-public void Configure(IApplicationBuilder app)
+public void Configure(IApplicationBuilder app, IHostingEnvironment env)
 {
     app.UseWebpack(withDevServer: env.IsDevelopment());
     app.UseStaticFiles();


### PR DESCRIPTION
Added missed parameter 'env' of type IHostingEnvironment in the Configure method