### PR TITLE
Bump framework version to netcoreapp3.1

### DIFF
--- a/samples/WebApp/Startup.cs
+++ b/samples/WebApp/Startup.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 
 namespace WebApp
 {
@@ -12,7 +13,7 @@ namespace WebApp
             services.AddWebpack();
         }
 
-        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
         {
             if (env.IsDevelopment())
             {
@@ -26,7 +27,8 @@ namespace WebApp
             }
 
             app.UseStaticFiles();
-            app.UseMvc();
+            app.UseRouting();
+            app.UseEndpoints(endpoints => endpoints.MapControllers());
         }
     }
 }

--- a/samples/WebApp/StartupWithPublicPath.cs
+++ b/samples/WebApp/StartupWithPublicPath.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 
 namespace WebApp
 {
@@ -28,7 +29,7 @@ namespace WebApp
                 .AddStaticOptions(options => options.RequestPath = "/assets/");
         }
 
-        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
         {
             app.UsePathBase("/public/");
 
@@ -44,7 +45,8 @@ namespace WebApp
             }
 
             app.UseStaticFiles();
-            app.UseMvc();
+            app.UseRouting();
+            app.UseEndpoints(endpoints => endpoints.MapControllers());
         }
     }
 }

--- a/samples/WebApp/StartupWithStaticFileOptions.cs
+++ b/samples/WebApp/StartupWithStaticFileOptions.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 
 namespace WebApp
 {
@@ -22,7 +23,7 @@ namespace WebApp
             });
         }
 
-        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
         {
             if (env.IsDevelopment())
             {
@@ -36,7 +37,8 @@ namespace WebApp
             }
 
             app.UseStaticFiles();
-            app.UseMvc();
+            app.UseRouting();
+            app.UseEndpoints(endpoints => endpoints.MapControllers());
         }
     }
 }

--- a/samples/WebApp/Views/Home/Index.cshtml
+++ b/samples/WebApp/Views/Home/Index.cshtml
@@ -11,7 +11,7 @@
     </ol>
     <div class="carousel-inner" role="listbox">
         <div class="item active">
-            <img src="~/images/banner1.svg")" alt="ASP.NET" class="img-responsive" />
+            <img src="~/images/banner1.svg" alt="ASP.NET" class="img-responsive" />
             <div class="carousel-caption" role="option">
                 <p>
                     Learn how to build ASP.NET apps that can run anywhere.

--- a/samples/WebApp/WebApp.csproj
+++ b/samples/WebApp/WebApp.csproj
@@ -1,16 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.0" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="2.0.0" />
-  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Webpack.AspNetCore\Webpack.AspNetCore.csproj" />

--- a/src/Webpack.AspNetCore/DevServer/Internal/DevServerManifestReader.cs
+++ b/src/Webpack.AspNetCore/DevServer/Internal/DevServerManifestReader.cs
@@ -1,8 +1,8 @@
-﻿using Newtonsoft.Json;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Net.Http;
 using System.Net.Http.Headers;
+using System.Text.Json;
 using System.Threading.Tasks;
 using Webpack.AspNetCore.Internal;
 
@@ -54,7 +54,7 @@ namespace Webpack.AspNetCore.DevServer.Internal
                     }
 
                     var manifestJson = await response.Content.ReadAsStringAsync();
-                    manifest = JsonConvert.DeserializeObject<Dictionary<string, string>>(manifestJson);
+                    manifest = JsonSerializer.Deserialize<Dictionary<string, string>>(manifestJson);
 
                     CacheManifest(etag, manifest);
 

--- a/src/Webpack.AspNetCore/Static/Internal/PhysicalFileManifestReader.cs
+++ b/src/Webpack.AspNetCore/Static/Internal/PhysicalFileManifestReader.cs
@@ -1,7 +1,7 @@
-﻿using Newtonsoft.Json;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Text.Json;
 using System.Threading.Tasks;
 using Webpack.AspNetCore.Internal;
 
@@ -43,7 +43,7 @@ namespace Webpack.AspNetCore.Static.Internal
                 {
                     var manifestJson = await manifestReader.ReadToEndAsync();
 
-                    return JsonConvert.DeserializeObject<Dictionary<string, string>>(
+                    return JsonSerializer.Deserialize<Dictionary<string, string>>(
                         manifestJson
                     );
                 }

--- a/src/Webpack.AspNetCore/Static/Internal/StaticContext.cs
+++ b/src/Webpack.AspNetCore/Static/Internal/StaticContext.cs
@@ -14,7 +14,7 @@ namespace Webpack.AspNetCore.Static.Internal
         private readonly IFileProvider fileProvider;
         private readonly StaticOptions options;
 
-        public StaticContext(IOptions<StaticOptions> optionsAccessor, IHostingEnvironment env)
+        public StaticContext(IOptions<StaticOptions> optionsAccessor, IWebHostEnvironment env)
         {
             if (optionsAccessor == null)
             {

--- a/src/Webpack.AspNetCore/Webpack.AspNetCore.csproj
+++ b/src/Webpack.AspNetCore/Webpack.AspNetCore.csproj
@@ -10,12 +10,10 @@
     <RepositoryUrl>https://github.com/sergeysolovev/webpack-aspnetcore</RepositoryUrl>
     <PackageReleaseNotes>Release notes are at https://github.com/sergeysolovev/webpack-aspnetcore/releases</PackageReleaseNotes>
     <PackageLicenseUrl>https://github.com/sergeysolovev/webpack-aspnetcore/blob/master/LICENSE</PackageLicenseUrl>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
-
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore" Version="2.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.0.0" />
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 
 </Project>

--- a/test/WebSites/BasicWebSite/BasicWebSite.csproj
+++ b/test/WebSites/BasicWebSite/BasicWebSite.csproj
@@ -2,17 +2,13 @@
   <PropertyGroup>
     <DefaultItemExcludes>$(DefaultItemExcludes);node_modules\**</DefaultItemExcludes>
   </PropertyGroup>
-  
-  <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
-  </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.0" />
-  </ItemGroup>
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+  </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\Webpack.AspNetCore\Webpack.AspNetCore.csproj" />
   </ItemGroup>
-  
+
 </Project>

--- a/test/WebSites/BasicWebSite/Startup.cs
+++ b/test/WebSites/BasicWebSite/Startup.cs
@@ -1,0 +1,31 @@
+﻿using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace BasicWebSite
+{
+    public class Startup
+    {
+        private static readonly string publicPath = "/public/";
+
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.AddMvc();
+
+            services.AddWebpack().AddDevServerOptions(opts =>
+            {
+                opts.PublicPath = publicPath;
+                opts.Port = 8081;
+                opts.ManifestFileName = "webpack-assets.json";
+            });
+        }
+
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
+        {
+            app.UsePathBase(publicPath);
+            app.UseWebpackDevServer();
+            app.UseRouting();
+            app.UseEndpoints(endpoints => endpoints.MapDefaultControllerRoute());
+        }
+    }
+}

--- a/test/WebSites/BasicWebSite/StartupWithStaticFileOption.cs
+++ b/test/WebSites/BasicWebSite/StartupWithStaticFileOption.cs
@@ -1,0 +1,33 @@
+﻿using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace BasicWebSite
+{
+    public class StartupWithStaticFileOption
+    {
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.AddMvc();
+            services.AddWebpack().AddStaticOptions(opts =>
+            {
+                opts.RequestPath = "/public/";
+                opts.ManifestDirectoryPath = "/dist/";
+                opts.OnPrepareResponse = respContext =>
+                    respContext.Context.Response.Headers.Add(
+                        key: "Cache-control",
+                        value: "public,max-age=31536000"
+                    );
+                opts.UseStaticFileMiddleware = true;
+            });
+        }
+
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
+        {
+            app.UseWebpackStatic();
+            app.UseRouting();
+            app.UseEndpoints(endpoints => endpoints.MapDefaultControllerRoute());
+        }
+    }
+}

--- a/test/Webpack.AspNetCore.Tests.Integration/DevServer/DevServerTestContext.cs
+++ b/test/Webpack.AspNetCore.Tests.Integration/DevServer/DevServerTestContext.cs
@@ -1,10 +1,10 @@
-﻿using Microsoft.AspNetCore.Builder;
+﻿using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.Net.Http;
+using BasicWebSite;
 
 namespace Webpack.AspNetCore.Tests.Integration.DevServer
 {
@@ -19,28 +19,13 @@ namespace Webpack.AspNetCore.Tests.Integration.DevServer
         public DevServerTestContext()
         {
             var builder = new WebHostBuilder()
-                .UseContentRoot(WebSite.GetContentRoot())
                 .ConfigureServices(services =>
-                {
-                    services.AddMvc();
-
-                    services.AddWebpack().AddDevServerOptions(opts =>
-                    {
-                        opts.PublicPath = publicPath;
-                        opts.Port = 8081;
-                        opts.ManifestFileName = "webpack-assets.json";
-                    });
-
                     services.AddSingleton<IHttpContextAccessor>(
                         new CustomHttpContextAccessor(publicPath)
-                    );
-                })
-                .Configure(app =>
-                {
-                    app.UsePathBase(publicPath);
-                    app.UseWebpackDevServer();
-                    app.UseMvcWithDefaultRoute();
-                });
+                    )
+                )
+                .UseStartup<Startup>()
+                .UseContentRoot(WebSite.GetContentRoot());
 
             server = new TestServer(builder);
             client = server.CreateClient();

--- a/test/Webpack.AspNetCore.Tests.Integration/Static/StaticTestContext.cs
+++ b/test/Webpack.AspNetCore.Tests.Integration/Static/StaticTestContext.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Hosting;
+﻿using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
@@ -7,6 +6,7 @@ using System;
 using System.IO;
 using System.Net.Http;
 using System.Threading.Tasks;
+using BasicWebSite;
 using Webpack.AspNetCore.Static.Internal;
 
 namespace Webpack.AspNetCore.Tests.Integration.Static
@@ -48,28 +48,11 @@ namespace Webpack.AspNetCore.Tests.Integration.Static
                     .UseContentRoot(WebSite.GetContentRoot())
                     .UseWebRoot(webRoot)
                     .ConfigureServices(services =>
-                    {
-                        services.AddMvc();
-                        services.AddWebpack().AddStaticOptions(opts =>
-                        {
-                            opts.RequestPath = "/public/";
-                            opts.ManifestDirectoryPath = "/dist/";
-                            opts.OnPrepareResponse = respContext =>
-                                respContext.Context.Response.Headers.Add(
-                                    key: "Cache-control",
-                                    value: "public,max-age=31536000"
-                                );
-                            opts.UseStaticFileMiddleware = true;
-                        });
-
                         services.AddSingleton<IHttpContextAccessor>(
                             new CustomHttpContextAccessor()
-                        );
-                    })
-                    .Configure(app => {
-                        app.UseWebpackStatic();
-                        app.UseMvcWithDefaultRoute();
-                    });
+                        )
+                    )
+                    .UseStartup<StartupWithStaticFileOption>();
 
                 server = new TestServer(builder);
                 setupWaitingForStorageUpdate();

--- a/test/Webpack.AspNetCore.Tests.Integration/Webpack.AspNetCore.Tests.Integration.csproj
+++ b/test/Webpack.AspNetCore.Tests.Integration/Webpack.AspNetCore.Tests.Integration.csproj
@@ -3,7 +3,7 @@
     <PreserveCompilationContext>true</PreserveCompilationContext>
   </PropertyGroup>
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <Content Include="assets\**">
@@ -18,11 +18,14 @@
     <ProjectReference Include="..\WebSites\BasicWebSite\BasicWebSite.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.0.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0-beta.1.build3958" />
-    <PackageReference Include="xunit" Version="2.4.0-beta.1.build3958" />
-    <DotNetCliToolReference Include="dotnet-xunit" Version="2.4.0-beta.1.build3958" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.10" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>
   <Target Name="CopyDepsFiles" AfterTargets="Build" Condition="'$(TargetFramework)'!=''">
     <ItemGroup>


### PR DESCRIPTION
Hi 🙌 

I am currently considering using this library in an ASP.NET Core 3.1 project.

Currently, netcore5.0 has already been released, but is it possible to upgrade the framework version to 3.1 first?

> In this PR, I have turned off support for the netstandard, but for the netframework, support may be needed.